### PR TITLE
pick a random value for prevrandao for a mined block

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -863,6 +863,9 @@ impl Backend {
             env.block.basefee = current_base_fee.to_alloy();
             env.block.timestamp = rU256::from(self.time.next_timestamp());
 
+            // pick a random value for prevrandao
+            env.block.prevrandao = Some(B256::random());
+
             let best_hash = self.blockchain.storage.read().best_hash;
 
             if self.prune_state_history_config.is_state_history_supported() {


### PR DESCRIPTION
This addresses https://github.com/foundry-rs/foundry/issues/5056, but since adding a test for this one is non-trivial (to access prevrandao value one needs to add one more contract to the codebase, deploy it and call it), this PR is not for foundry-rs repo.